### PR TITLE
Isolated Modules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * State of the Retrieval<T>
  */
-export const enum RetrievalState {
+export enum RetrievalState {
   Idle,
   Retrieving,
   Succeeded,


### PR DESCRIPTION
Create react scripts requires isolated modules flag enabled.  With this, exported const enums don't work...but an exported enum works the same and just fine.  